### PR TITLE
First draft of prometheus example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Pipfile.lock
+.cloudless

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[dev-packages]
+pylint = "*"
+
+[packages]
+cloudless = "*"
+requests = "*"
+
+[requires]
+python_version = "3.6"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+# Prometheus Example
+
+This is an example of creating a simple single node Prometheus setup. Note that
+this blueprint references an image created by the base image scripts at
+[https://github.com/getcloudless/example-base-image](https://github.com/getcloudless/example-base-image),
+so this will fail unless you run that first.
+
+## Installation
+
+You can clone this repo, and then install Cloudless and the other dependencies
+using [pipenv](https://pipenv.readthedocs.io/en/latest/):
+
+```shell
+$ git clone https://github.com/getcloudless/example-prometheus.git
+$ cd example-prometheus
+$ pipenv install
+$ pipenv shell
+$ which cldls
+```
+
+## Usage
+
+The file at `blueprint.yml` can be used in any service command:
+
+```
+cldls service create blueprint.yml
+```
+
+You can run the service's regression tests with:
+
+```
+cldls service-test run service_test_configuration.yml
+```
+
+Note that these are completely independent of what provider you're using,
+assuming you've already built the [Base
+Image](https://github.com/getcloudless/example-base-image).
+
+## Workflow
+
+The main value of the test framework is that it is focused on the workflow of
+actually developing a service.  For example, if you want to deploy a service
+(and all its dependencies) that you can work on without running the full test,
+you can run:
+
+```
+cldls service-test deploy service_test_configuration.yml
+```
+
+This command saves the SSH keys locally and will display the SSH command that
+you need to run to log into the instance.
+
+Now, say you want to actually check that the service is behaving as expected:
+
+```
+cldls service-test check service_test_configuration.yml
+```
+
+You can run this as many times as you want until it's working, as you are logged
+in.  Finally, clean everything up with:
+
+```
+cldls service-test cleanup service_test_configuration.yml
+```
+
+You're done!  The run step will run all these steps in order.

--- a/blueprint.yml
+++ b/blueprint.yml
@@ -1,0 +1,27 @@
+---
+network:
+  subnetwork_max_instance_count: 768
+
+placement:
+  availability_zones: 3
+
+instance:
+  public_ip: True
+  memory: 1GB
+  cpus: 1
+  gpu: false
+  disks:
+    - size: 8GB
+      type: standard
+      device_name: /dev/sda1
+
+image:
+  name: "cloudless-example-base-image-v0"
+
+initialization:
+  - path: "prometheus_startup_script.sh"
+    vars:
+      cloudless_test_framework_ssh_key:
+        required: false
+      cloudless_test_framework_ssh_username:
+        required: false

--- a/blueprint_fixture.py
+++ b/blueprint_fixture.py
@@ -1,0 +1,54 @@
+"""
+Apache Test Fixture
+
+This fixture doesn't do any setup, but verifies that the created service is
+running default apache.
+"""
+import requests
+from cloudless.testutils.blueprint_tester import call_with_retries
+from cloudless.testutils.fixture import BlueprintTestInterface, SetupInfo
+from cloudless.types.networking import CidrBlock
+
+RETRY_DELAY = float(10.0)
+RETRY_COUNT = int(6)
+
+class BlueprintTest(BlueprintTestInterface):
+    """
+    Fixture class that creates the dependent resources.
+    """
+    def setup_before_tested_service(self, network):
+        """
+        Create the dependent services needed to test this service.
+        """
+        # Since this service has no dependencies, do nothing.
+        return SetupInfo({}, {})
+
+    def setup_after_tested_service(self, network, service, setup_info):
+        """
+        Do any setup that must happen after the service under test has been
+        created.
+        """
+        my_ip = requests.get("http://ipinfo.io/ip")
+        test_machine = CidrBlock(my_ip.content.decode("utf-8").strip())
+        self.client.paths.add(test_machine, service, 9090)
+
+    def verify(self, network, service, setup_info):
+        """
+        Given the network name and the service name of the service under test,
+        verify that it's behaving as expected.
+        """
+        def check_prometheus():
+            instances = self.client.service.get_instances(service)
+            assert instances, "No instances found!"
+            for instance in instances:
+                endpoint = 'http://%s:9090/api/v1/query' % instance.public_ip
+                params = {"query": "prometheus_build_info"}
+                response = requests.get(endpoint, params=params)
+                api_response = response.json()
+                assert api_response["status"] == "success"
+                monitoring_self = False
+                for result in api_response["data"]["result"]:
+                    if result["metric"]["instance"] == "localhost:9090":
+                        monitoring_self = True
+                assert monitoring_self, "Found no metrics for Prometheus"
+        call_with_retries(check_prometheus, RETRY_COUNT, RETRY_DELAY)

--- a/prometheus_startup_script.sh
+++ b/prometheus_startup_script.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+{% if cloudless_test_framework_ssh_key %}
+adduser "{{ cloudless_test_framework_ssh_username }}" --disabled-password --gecos "Cloudless Test User"
+echo "{{ cloudless_test_framework_ssh_username }} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+mkdir /home/{{ cloudless_test_framework_ssh_username }}/.ssh/
+echo "{{ cloudless_test_framework_ssh_key }}" >> /home/{{ cloudless_test_framework_ssh_username }}/.ssh/authorized_keys
+{% endif %}
+
+# Install Docker
+apt-get update
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu
+$(lsb_release -cs) stable"
+apt-get update
+apt-cache policy docker-ce
+apt-get install -y docker-ce
+systemctl status docker
+
+# Configure with some default config, to monitor itself
+# (https://prometheus.io/docs/prometheus/latest/getting_started/)
+cat <<EOF > /tmp/prometheus.yml
+global:
+  scrape_interval:     15s # By default, scrape targets every 15 seconds.
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+    monitor: 'codelab-monitor'
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: 'prometheus'
+
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 5s
+
+    static_configs:
+      - targets: ['localhost:9090']
+EOF
+
+# Run Prometheus
+docker run -d -p 9090:9090 \
+    -v /tmp/prometheus.yml:/etc/prometheus/prometheus.yml prom/prometheus

--- a/service_test_configuration.yml
+++ b/service_test_configuration.yml
@@ -1,0 +1,34 @@
+---
+# Configuration options for the blueprint testing framework.
+#
+# This file describes configuration for the blueprint test runner, which can
+# create, verify, and cleanup services based on a blueprint, providing a
+# deterministic way to test the way instances actually behave in a deployment.
+# See https://docs.getcloudless.com/ for more details.
+
+# Configuration for service creation.
+create:
+
+  # Number of instances needed for the test.
+  count: 1
+
+  # Blueprint file to use to create test service.  This is the default.
+  blueprint: blueprint.yml
+
+  # This is a fixture that describes any pre setup (e.g. necessary services that
+  # this service being tested needs to run) and post setup (e.g. adding the
+  # right firewall rules) that needs to be done to properly test this blueprint.
+  # These are the defaults.  See blueprint_fixture.py for more details.
+  fixture_type: python-blueprint-fixture
+  fixture_options:
+    module_name: blueprint_fixture
+
+# Configuration for service verification.
+verify:
+
+  # This happens to be the same fixture, but for verify this is the code that
+  # tests whether the running service is behaving as expected.  These are the
+  # defaults.  See blueprint_fixture.py for more details.
+  fixture_type: python-blueprint-fixture
+  fixture_options:
+    module_name: blueprint_fixture


### PR DESCRIPTION
This example deploys the simplest possible file backed Prometheus server
and tests that it's running.  Things it does NOT have, but that should
be added later:

- High availability support using a storage backend.
- Discover monitored services using service discovery.
- Have some kind of story for keeping configuration up to date.
  - Redeploying isn't a viable way to do this without external storage.
- Federation, or configuration to monitor other Prometheus instances.